### PR TITLE
avoid using experimental smartmatch

### DIFF
--- a/lib/API/Instagram/User.pm
+++ b/lib/API/Instagram/User.pm
@@ -206,11 +206,10 @@ sub relationship {
 	my $self    = shift;
 	my $action  = shift;
 	my $url     = sprintf "users/%s/relationship", $self->id;
-	my @actions = qw/ follow unfollow block unblock approve ignore/;
+	my %actions = map { $_ => 1 } qw/ follow unfollow block unblock approve ignore/;
 
-	use experimental 'smartmatch';
 	if ( $action ) {
-		if ( $action ~~ @actions ){
+		if ( $actions{ $action } ){
 			return $self->_api->_post( $url, { action => $action } )
 		}
 		carp "Invalid action";


### PR DESCRIPTION
from `perldelta`:

_"Smart match, added in v5.10.0 and significantly revised in v5.10.1, has been a regular point of complaint.  Although there are a number of ways in which it is useful, it has also proven problematic and confusing for both users and implementors of Perl. There have been a number of proposals on how to best address the problem.  It is clear that smartmatch is almost certainly either going to change or go away in the future.  **Relying on its current behavior is not recommended.**"_

This patch provides a simple way out of smartmatching for API::Instagram's use case :)